### PR TITLE
Fix compiler errors related to Term enum and DoubleEndedIterator implementation

### DIFF
--- a/src/fun/mod.rs
+++ b/src/fun/mod.rs
@@ -633,7 +633,7 @@ impl Term {
       | Term::App { fun: fst, arg: snd, .. }
       | Term::Oper { fst, snd, .. } => ChildrenIter::Two([fst.as_mut(), snd.as_mut()]),
       Term::Lam { pat, bod, .. } => ChildrenIter::One([bod.as_mut()]),
-      Term::With { bod, .. } => ChildrenIter::One([bod.as_mut()]),
+      Term::With { bod, .. } | Term::Open { bod, .. } => ChildrenIter::One([bod.as_mut()]),
       Term::Var { .. }
       | Term::Link { .. }
       | Term::Num { .. }
@@ -765,7 +765,7 @@ impl Term {
         ChildrenIter::Two([(fst.as_mut(), BindsIter::Zero([])), (snd.as_mut(), BindsIter::Zero([]))])
       }
       Term::Lam { pat, bod, .. } => ChildrenIter::One([bod.as_mut()]),
-      Term::With { bod, .. } => ChildrenIter::One([bod.as_mut()]),
+      Term::With { bod, .. } | Term::Open { bod, .. } => ChildrenIter::One([bod.as_mut()]),
       Term::Var { .. }
       | Term::Link { .. }
       | Term::Num { .. }

--- a/src/fun/transform/expand_main.rs
+++ b/src/fun/transform/expand_main.rs
@@ -94,7 +94,7 @@ impl Term {
       | Term::Mat { .. }
       | Term::Swt { .. }
       | Term::Fold { .. }
-      | Term::Bramar { .. }
+      | Term::Bend { .. }
       | Term::Def { .. }
       | Term::Era
       | Term::Err => {}

--- a/src/fun/transform/linearize_vars.rs
+++ b/src/fun/transform/linearize_vars.rs
@@ -114,7 +114,7 @@ fn dup_name(nam: &Name, uses: u64) -> Name {
 
 impl Term {
   /// Because multiple children can share the same binds, this function is very restricted.
-  /// Should only be called after desugaring bramars/folds/matches/switches.
+  /// Should only be called after desugaring bends/folds/matches/switches.
   pub fn children_mut_with_binds_mut(
     &mut self,
   ) -> impl DoubleEndedIterator<Item = (&mut Term, impl DoubleEndedIterator<Item = &mut Option<Name>>)> {
@@ -157,7 +157,7 @@ impl Term {
       | Term::Err => ChildrenIter::Zero([]),
       Term::Mat { .. } => unreachable!("'match' should be removed in earlier pass"),
       Term::Fold { .. } => unreachable!("'fold' should be removed in earlier pass"),
-      Term::Bramar { .. } => unreachable!("'bramar' should be removed in earlier pass"),
+      Term::Bend { .. } => unreachable!("'bend' should be removed in earlier pass"),
       Term::Open { .. } => unreachable!("'open' should be removed in earlier pass"),
       Term::Def { .. } => unreachable!("'def' should be removed in earlier pass"),
     }


### PR DESCRIPTION
Related to #3

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/mvespin1/BramarProgramingLanguage/pull/4?shareId=9d5b0d23-ad47-4e76-a486-e6a2d120664e).